### PR TITLE
Add unit and functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,37 @@ logs:
 clean: stop
 	docker rmi $(IMAGE_NAME) || true
 
-.PHONY: all build run stop logs clean
+# Lancer les tests unitaires
+test-unit:
+	@echo "Running unit tests..."
+	go test -v ./...
+
+# Lancer les tests fonctionnels
+test-functional: build
+	@echo "--> Running functional tests..."
+	@sh -c ' \
+		set -e; \
+		NETWORK_NAME=expenseapp-test-net; \
+		APP_CONTAINER_NAME=expenseapp-test-app; \
+		TEST_IMAGE_NAME=$(IMAGE_NAME)-test; \
+		cleanup() { \
+			echo "    Cleaning up..."; \
+			docker stop $$APP_CONTAINER_NAME >/dev/null 2>&1 || true; \
+			docker rm $$APP_CONTAINER_NAME >/dev/null 2>&1 || true; \
+			docker network rm $$NETWORK_NAME >/dev/null 2>&1 || true; \
+		}; \
+		trap cleanup EXIT; \
+		echo "    Setting up test environment..."; \
+		docker network create $$NETWORK_NAME >/dev/null 2>&1 || true; \
+		docker run -d --name $$APP_CONTAINER_NAME --network $$NETWORK_NAME $(IMAGE_NAME) >/dev/null; \
+		echo "    Building test image..."; \
+		docker build -t $$TEST_IMAGE_NAME -f tests/Dockerfile . >/dev/null; \
+		echo "    Running tests..."; \
+		docker run --network $$NETWORK_NAME --rm -e API_URL=http://$$APP_CONTAINER_NAME:8080 $$TEST_IMAGE_NAME; \
+		echo "    Functional tests passed."; \
+	'
+
+# Lancer tous les tests
+test: test-unit test-functional
+
+.PHONY: all build run stop logs clean test-unit test-functional test

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashPassword(t *testing.T) {
+	password := "password123"
+	hash, err := hashPassword(password)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, hash)
+	assert.NotEqual(t, password, hash)
+}
+
+func TestCheckPassword(t *testing.T) {
+	password := "password123"
+	hash, err := hashPassword(password)
+	assert.NoError(t, err)
+
+	// Test correct password
+	err = checkPassword(hash, password)
+	assert.NoError(t, err)
+
+	// Test incorrect password
+	err = checkPassword(hash, "wrongpassword")
+	assert.Error(t, err)
+}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.20-alpine
+
+WORKDIR /app
+
+# Copy test files
+COPY . .
+
+# Copy go.mod from parent directory
+COPY ../go.mod .
+
+# Install dependencies
+RUN go mod tidy
+
+# Run the tests
+CMD ["go", "test", "-v", "."]

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -1,0 +1,40 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogin(t *testing.T) {
+	apiURL := os.Getenv("API_URL")
+	if apiURL == "" {
+		apiURL = "http://localhost:8080"
+	}
+
+	// Create login request
+	loginData := map[string]string{
+		"email":    "admin@example.com",
+		"password": "admin",
+	}
+	jsonData, err := json.Marshal(loginData)
+	assert.NoError(t, err)
+
+	// Send request
+	resp, err := http.Post(apiURL+"/api/auth/login", "application/json", bytes.NewBuffer(jsonData))
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Check status code
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Check response body
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+	assert.Contains(t, result, "token")
+}


### PR DESCRIPTION
This commit adds a testing framework to your project, including unit tests for the Go backend and a functional test suite that runs against the API in a Docker container.

- **Unit Tests:**
  - I added `auth_test.go` with unit tests for the `hashPassword` and `checkPassword` functions.

- **Functional Tests:**
  - I created a new `tests` directory for the functional test program.
  - The test program is written in Go (`tests/main_test.go`) and tests the `/api/auth/login` endpoint.
  - A `Dockerfile` (`tests/Dockerfile`) is provided to run the tests in a container.

- **Makefile:**
  - I updated the `Makefile` with new targets for testing:
    - `test-unit`: runs the unit tests.
    - `test-functional`: sets up a test environment with Docker containers and runs the functional API tests.
    - `test`: runs both unit and functional tests.