### PR TITLE
Fix: Enable CGO for SQLite and make credentials configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Étape 1: Construire l'application Go
 FROM golang:1.20-alpine AS builder
 
-# Installer git
-RUN apk add --no-cache git
+# Installer git et les outils de construction C
+RUN apk add --no-cache git gcc musl-dev
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN go mod tidy
 RUN go mod vendor
 
 # Construire l'exécutable Go en utilisant les dépendances vendored
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -installsuffix cgo -o /app/expenseapp .
+RUN CGO_ENABLED=1 GOOS=linux go build -mod=vendor -a -installsuffix cgo -o /app/expenseapp .
 
 # Étape 2: Créer l'image finale avec Nginx
 FROM nginx:alpine

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
-# expense-app
-golang expense tracking app
+# Expense App
+
+A simple expense tracking application built with Go and Svelte.
+
+## Getting Started
+
+To get the application running locally, you'll need to have Docker and Docker Compose installed.
+
+1.  **Build and run the application:**
+
+    ```bash
+    docker-compose up --build
+    ```
+
+2.  **Access the application:**
+
+    The application will be available at `http://localhost:8080`.
+
+## Configuration
+
+The application can be configured using environment variables.
+
+| Variable           | Description                                                                                                | Default               |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- | --------------------- |
+| `PORT`             | The port on which the Go backend server will listen.                                                       | `8081`                |
+| `DATADIR`          | The directory where the SQLite database and other data will be stored.                                     | `./data`              |
+| `JWT_SECRET`       | The secret key used to sign JSON Web Tokens.                                                               | `secret`              |
+| `ADMIN_EMAIL`      | The email for the initial super admin user, created on first run.                                          | `admin@example.com`   |
+| `ADMIN_PASSWORD`   | The password for the initial super admin user. **It is strongly recommended to change this.**                | `admin`               |
+
+### Example with `docker run`
+
+You can also run the application without Docker Compose by passing the environment variables directly to the `docker run` command.
+
+```bash
+docker run -d \
+  -p 8080:8080 \
+  -e ADMIN_EMAIL=myadmin@example.com \
+  -e ADMIN_PASSWORD=supersecretpassword \
+  -e JWT_SECRET=anothersecret \
+  -v $(pwd)/data:/data \
+  --name expense-app \
+  expense-app:latest
+```
+
+**Note:** You would first need to build the image, for example with `docker build -t expense-app:latest .`.

--- a/models.go
+++ b/models.go
@@ -4,6 +4,7 @@ import (
     "database/sql"
     "errors"
     "fmt"
+    "os"
     "time"
 )
 
@@ -225,8 +226,8 @@ func seedPermissionsAndGroups(db *sql.DB) error {
 }
 
 // seedSuperAdmin ensures that at least one user exists. If none, it creates a default super admin
-// user and assigns them to the Administrateurs group. The default credentials are defined here and
-// should be changed immediately after first login.
+// user and assigns them to the Administrateurs group. The default credentials are read from
+// environment variables ADMIN_EMAIL and ADMIN_PASSWORD, with fallbacks.
 func seedSuperAdmin(db *sql.DB) error {
     var count int
     if err := db.QueryRow("SELECT COUNT(*) FROM users").Scan(&count); err != nil {
@@ -235,9 +236,15 @@ func seedSuperAdmin(db *sql.DB) error {
     if count > 0 {
         return nil
     }
-    // Create default super admin user
-    email := "admin@example.com"
-    password := "admin"
+	// Create default super admin user from env or fall back to defaults
+	email := os.Getenv("ADMIN_EMAIL")
+	if email == "" {
+		email = "admin@example.com"
+	}
+	password := os.Getenv("ADMIN_PASSWORD")
+	if password == "" {
+		password = "admin"
+	}
     // Hash password using bcrypt
     hash, err := hashPassword(password)
     if err != nil {


### PR DESCRIPTION
This commit addresses two issues:

1.  The Go binary was being built with CGO_ENABLED=0, which caused the go-sqlite3 driver to fail during database initialization. This has been fixed by enabling CGO in the Dockerfile and adding the necessary build tools (gcc, musl-dev).

2.  The initial admin credentials were hardcoded. The application now reads the admin email and password from the ADMIN_EMAIL and ADMIN_PASSWORD environment variables, with sensible defaults.

Additionally, the README.md has been significantly improved with sections on getting started and configuration, documenting all relevant environment variables.

## Summary by Sourcery

Enable CGO for SQLite support, make initial admin credentials configurable via environment variables, and improve the README documentation.

Bug Fixes:
- Fix go-sqlite3 initialization by enabling CGO support

Enhancements:
- Make initial super admin credentials configurable via ADMIN_EMAIL and ADMIN_PASSWORD environment variables with defaults

Build:
- Install gcc and musl-dev and enable CGO in the Dockerfile

Documentation:
- Revise README with Getting Started guide and document configuration environment variables