### PR TITLE
Fix Docker build failure with go-sqlite3 on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Étape 1: Construire l'application Go
-FROM golang:1.20-alpine AS builder
+FROM golang:1.20-alpine3.17 AS builder
 
 # Installer git et les outils de construction C
 RUN apk add --no-cache git gcc musl-dev


### PR DESCRIPTION
The Docker build was failing with CGO compilation errors related to `pread64` and `pwrite64` in the `go-sqlite3` package. This is caused by an incompatibility between the version of `go-sqlite3` and a recent version of the `musl` C library in the `golang:1.20-alpine` base image.

This change pins the builder base image to `golang:1.20-alpine3.17`, which is known to have a compatible version of `musl`, resolving the build errors.